### PR TITLE
remove extraneous links

### DIFF
--- a/wadl2rst/templates/method.jinja
+++ b/wadl2rst/templates/method.jinja
@@ -4,9 +4,6 @@
 =
 {%- endfor %}
 
-`Request <{{filename}}#request>`__
-`Response <{{filename}}#response>`__
-
 .. rest_method:: {{http_method}} {{uri}}
 
 {{docs_rst}}


### PR DESCRIPTION
There are some defaulted response / request links that are not needed
added to the template. These mostly create noise in the output.
